### PR TITLE
Add mutable access for basic, Option, and Result tappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,17 @@
 A simple crate exposing tapping functionality for all types, and extended
 functionality for `Option`, `Result` & `Future`. Often useful for logging.
 
+The tap operation takes, and then returns, full ownership of the variable being
+tapped. This means that the closure may have mutable access to the variable,
+even if the variable is otherwise immutable. Mutating closures require the
+`|mut name|` pattern, and so can be easily distinguished from non-mutating taps.
+
 ## Features
 
 * `future` - Exposes the `TapFutureOps` trait, providing `tap_ready`,
   `tap_not_ready` & `tap_err` (requires the *futures* crate).
+
+  Futures do not provide mutable access for tap closures.
 
 ## Example
 
@@ -46,6 +53,16 @@ fn basic() {
     // Options have `tap_some` & `tap_none` available.
     let _: Option<i32> = None.tap_none(|| foo = 10);
     assert_eq!(foo, 10);
+}
+
+#[test]
+fn mutable() {
+    let base = [1, 2, 3];
+    let mutated = base.tap(|mut arr| for elt in arr.iter_mut() {
+        *elt *= 2;
+    });
+    assert_eq!(mutated, [2, 4, 6]);
+    //  base was consumed, and then returned into mutated, and is out of scope.
 }
 
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,23 +11,23 @@ extern crate matches;
 /// Tap operations for `Result`.
 pub trait TapResultOps<T, E> {
     /// Executes a closure if the value is `Result::Ok(T)`.
-    fn tap_ok<R, F: FnOnce(&T) -> R>(self, f: F) -> Self;
+    fn tap_ok<R, F: FnOnce(&mut T) -> R>(self, f: F) -> Self;
 
     /// Executes a closure if the value is `Result::Err(E)`.
-    fn tap_err<R, F: FnOnce(&E) -> R>(self, f: F) -> Self;
+    fn tap_err<R, F: FnOnce(&mut E) -> R>(self, f: F) -> Self;
 }
 
 impl<T, E> TapResultOps<T, E> for Result<T, E> {
-    fn tap_ok<R, F: FnOnce(&T) -> R>(self, f: F) -> Self {
-        if let Ok(val) = self.as_ref() {
-            let _ = f(val);
+    fn tap_ok<R, F: FnOnce(&mut T) -> R>(mut self, f: F) -> Self {
+        if let Ok(mut val) = self.as_mut() {
+            let _ = f(&mut val);
         }
         self
     }
 
-    fn tap_err<R, F: FnOnce(&E) -> R>(self, f: F) -> Self {
-        if let Err(val) = self.as_ref() {
-            let _ = f(val);
+    fn tap_err<R, F: FnOnce(&mut E) -> R>(mut self, f: F) -> Self {
+        if let Err(mut val) = self.as_mut() {
+            let _ = f(&mut val);
         }
         self
     }
@@ -36,15 +36,15 @@ impl<T, E> TapResultOps<T, E> for Result<T, E> {
 /// Tap operations for `Option`.
 pub trait TapOptionOps<T> {
     /// Executes a closure if the value is `Option::Some(T)`.
-    fn tap_some<R, F: FnOnce(&T) -> R>(self, f: F) -> Self;
+    fn tap_some<R, F: FnOnce(&mut T) -> R>(self, f: F) -> Self;
 
     /// Executes a closure if the value is `Option::None`.
     fn tap_none<R, F: FnOnce() -> R>(self, f: F) -> Self;
 }
 
 impl<T> TapOptionOps<T> for Option<T> {
-    fn tap_some<R, F: FnOnce(&T) -> R>(self, f: F) -> Self {
-        if let Some(val) = self.as_ref() {
+    fn tap_some<R, F: FnOnce(&mut T) -> R>(mut self, f: F) -> Self {
+        if let Some(mut val) = self.as_mut() {
             let _ = f(val);
         }
         self
@@ -59,15 +59,15 @@ impl<T> TapOptionOps<T> for Option<T> {
 }
 
 /// Tap operations for all types.
-pub trait TapOps {
+pub trait TapOps : Sized {
     /// Executes a closure on an object.
-    fn tap<R, F: FnOnce(&Self) -> R>(self, f: F) -> Self where Self: Sized {
-        let _ = f(&self);
+    fn tap<R, F: FnOnce(&mut Self) -> R>(mut self, f: F) -> Self {
+        let _ = f(&mut self);
         self
     }
 }
 
-impl<T> TapOps for T {}
+impl<T> TapOps for T where T: Sized {}
 
 #[cfg(test)]
 mod tests {
@@ -94,5 +94,14 @@ mod tests {
         let mut foo = 0;
         assert_eq!(5.tap(|x| foo += *x), 5);
         assert_eq!(foo, 5);
+    }
+
+    #[test]
+    fn mutable() {
+        let base = [1, 2, 3];
+        let mutated = base.tap(|mut arr| for elt in arr.iter_mut() {
+            *elt *= 2;
+        });
+        assert_eq!(mutated, [2, 4, 6]);
     }
 }


### PR DESCRIPTION
I decided to use the ecosystem crate rather than [my own](https://github.com/myrrlyn/wyzyrdry-rs/blob/master/src/tap.rs), and discovered that I was using `tap` to do some things that yours could not support:

```rust
let v: Vec<i32> = vec![1, 2, 3].tap(|mut v| v.extend(vec![4, 5, 6]));
```

So this fork adds support for mutating closures to taps on basic, Option, and Result types.