### PR TITLE
Add tapping support for nom3's IResult type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,15 @@ license = "MIT"
 name = "tap"
 readme = "README.md"
 repository = "https://github.com/darfink/tap-rs"
-version = "0.2.1"
+version = "0.3.0"
 
 [dependencies.futures]
 optional = true
 version = "0.1.14"
+
+[dependencies.nom]
+optional = true
+version = "3"
 
 [dev-dependencies]
 matches = "0.1.6"
@@ -20,3 +24,4 @@ matches = "0.1.6"
 [features]
 default = []
 future = ["futures"]
+nom3 = ["nom"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ even if the variable is otherwise immutable. Mutating closures require the
 
   Futures do not provide mutable access for tap closures.
 
+* `nom3` - Exposes the `TapNomOps` trait, which provides `tap_done`,
+  `tap_error`, and `tap_incomplete` on their respective variants of
+  `nom::IResult`.
+
 ## Example
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,12 @@ pub use self::future::TapFutureOps;
 #[cfg(feature = "future")]
 mod future;
 
+#[cfg(feature = "nom3")]
+pub use self::nom::TapNomOps;
+
+#[cfg(feature = "nom3")]
+mod nom;
+
 #[cfg(test)]
 #[cfg_attr(test, macro_use)]
 extern crate matches;

--- a/src/nom.rs
+++ b/src/nom.rs
@@ -1,0 +1,86 @@
+extern crate nom;
+
+use self::nom::Err;
+use self::nom::IResult;
+use self::nom::Needed;
+
+/// Tap operations for nom's `IResult`.
+pub trait TapNomOps<I, O, E> {
+    /// Executes a closure if the value is `IResult::Done`.
+    ///
+    /// The closure will receive a tuple of (unparsed input, parsed output).
+    fn tap_done<R, F: FnOnce((&mut I, &mut O)) -> R>(self, f: F) -> Self;
+
+    /// Executes a closure if the value is `IResult::Error`.
+    fn tap_error<R, F: FnOnce(&mut Err<E>) -> R>(self, f: F) -> Self;
+
+    /// Executes a closure if the value is `IResult::Incomplete`.
+    fn tap_incomplete<R, F: FnOnce(&mut Needed) -> R>(self, f: F) -> Self;
+}
+
+impl<I, O, E> TapNomOps<I, O, E> for IResult<I, O, E> {
+    fn tap_done<R, F: FnOnce((&mut I, &mut O)) -> R>(mut self, f: F) -> Self {
+        use self::nom::IResult::Done;
+        if let &mut Done(ref mut rem, ref mut val) = &mut self {
+            let _ = f((rem, val));
+        }
+        self
+    }
+    fn tap_error<R, F: FnOnce(&mut Err<E>) -> R>(mut self, f: F) -> Self {
+        use self::nom::IResult::Error;
+        if let &mut Error(ref mut err) = &mut self {
+            let _ = f(&mut *err);
+        }
+        self
+    }
+    fn tap_incomplete<R, F: FnOnce(&mut Needed) -> R>(mut self, f: F) -> Self {
+        use self::nom::IResult::Incomplete;
+        if let &mut Incomplete(ref mut needed) = &mut self {
+            let _ = f(needed);
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::nom::ErrorKind;
+    type TestResult = IResult<&'static str, i32, u32>;
+
+    #[test]
+    fn done() {
+        let d: TestResult = IResult::Done(" 24", 42);
+        let mut n = 0;
+        d.tap_done(|(rem, val)| {
+            assert_eq!(val, &mut 42);
+            if let Ok(p) = rem.trim().parse::<i32>() {
+                n = p;
+            }
+        });
+        assert_eq!(n, 24);
+    }
+
+    #[test]
+    fn error() {
+        let e: TestResult = IResult::Error(ErrorKind::Custom('t' as u32));
+        let mut err_code = 0;
+        e.tap_error(|e| if let ErrorKind::Custom(c) = *e {
+            err_code = c;
+        });
+        assert_eq!(err_code, 116);
+    }
+
+    #[test]
+    #[should_panic]
+    fn incomplete() {
+        let i: TestResult = IResult::Incomplete(Needed::Unknown);
+        let mut more = 0;
+        i.tap_incomplete(|i| if let Needed::Size(s) = *i {
+            more = s;
+        }
+        else {
+            panic!();
+        });
+    }
+}


### PR DESCRIPTION
Tap the three variants of `nom`'s `IResult` enum.

When nom 4 is released, it will use the standard `Result` instead, but until then, this may be useful.